### PR TITLE
feat: optimize func deploy flow

### DIFF
--- a/library/deployFunction.js
+++ b/library/deployFunction.js
@@ -8,7 +8,7 @@ const models = tencentcloud.scf.v20180416.Models
 const camModels = tencentcloud.cam.v20190116.Models
 
 class DeployFunction extends Abstract {
-  async deploy(ns, funcObject) {
+  async deploy(ns, funcObject, updateCode = true) {
     const func = await this.getFunction(ns, funcObject.FuncName)
     if (!func) {
       await this.createFunction(ns, funcObject)
@@ -16,12 +16,14 @@ class DeployFunction extends Abstract {
       if (func.Runtime != funcObject.Properties.Runtime) {
         throw `Runtime error: Release runtime(${func.Runtime}) and local runtime(${funcObject.Properties.Runtime}) are inconsistent`
       }
-      this.context.debug('Updating code... ')
-      await this.updateFunctionCode(ns, funcObject)
-      if ((await this.checkStatus(ns, funcObject)) == false) {
-        throw `Function ${funcObject.FuncName} update failed`
+      if (updateCode) {
+        this.context.debug('Updating code... ')
+        await this.updateFunctionCode(ns, funcObject)
+        if ((await this.checkStatus(ns, funcObject)) == false) {
+          throw `Function ${funcObject.FuncName} update failed`
+        }
+        this.context.debug('Updating configure... ')
       }
-      this.context.debug('Updating configure... ')
       await this.updateConfiguration(ns, func, funcObject)
       return func
     }

--- a/library/utils.js
+++ b/library/utils.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const fs = require('fs')
+const crypto = require('crypto')
 const ignore = require('ignore')
 const _ = require('lodash')
 const Zip = require('./zip')
@@ -152,5 +153,14 @@ module.exports = {
       archive.on('error', (err) => reject(err))
       output.on('close', () => resolve(outputFilePath))
     })
+  },
+  getHash(content, encoding, type) {
+    return crypto
+      .createHash(type)
+      .update(content, encoding)
+      .digest('hex')
+  },
+  getFileHash(filePath) {
+    return this.getHash(fs.readFileSync(filePath, 'utf8'), 'utf8', 'md5')
   }
 }


### PR DESCRIPTION
## 背景

用户每次在执行部署时，即使用户代码没有修改，每次都会重新上传cos，并且更新函数代码，但是有时由于 cos 上传速度会很慢，所以导致部署很慢。

## 优化

每次用户代码压缩成 zip 文件后，获取 zip 文件的 `md5` 值，然后存储到 `state` 中，用户再次部署时，会比对就得 `md5` 值，如果一致，则只更新函数配置。如果不一致，则会上传cos，更新代码。