### PR TITLE
新增CodeUri写法/新增Tags配置，并删除默认Tags/新增生命周期功能

### DIFF
--- a/library/provider.js
+++ b/library/provider.js
@@ -41,8 +41,11 @@ class Provider {
       Type: 'TencentCloud::Serverless::Function',
       Properties: {
         CodeUri: {
-          Bucket: this.getCosBucketNme(),
-          Key: this.getFuntionBucketKey(this.namespace, functionName)
+          type: funcObject.codeUri.key ? 1 : funcObject.codeUri.bucket ? 2 : 0,
+          Bucket: funcObject.codeUri.bucket ? funcObject.codeUri.bucket : this.getCosBucketNme(),
+          Key: funcObject.codeUri.key
+            ? funcObject.codeUri.key
+            : this.getFuntionBucketKey(this.namespace, functionName)
         },
         Type: 'Event',
         Description: funcObject.description || 'This is a template function',
@@ -52,9 +55,7 @@ class Provider {
         Timeout: funcObject.timeout || 3,
         Region: funcObject.region || 'ap-guangzhou',
         Runtime: funcObject.runtime || 'Nodejs8.9',
-        Tags: {
-          CLI: 'Serverless'
-        }
+        Tags: funcObject.tags
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless/tencent-scf",
   "description": "Tencent Serverless Cloud Function",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -30,7 +30,8 @@
     "lodash": "^4.17.15",
     "qrcode-terminal": "^0.12.0",
     "ramda": "^0.26.1",
-    "serverless-tencent-auth-tool": "^1.0.14",
+    "serverless-tencent-auth-tool": "^2.0.1",
+    "serverless-tencent-tools": "^1.0.1",
     "tencentcloud-sdk-nodejs": "^3.0.89"
   },
   "devDependencies": {


### PR DESCRIPTION
SCF组件功能变更：
*  新增CodeUri写法
原有写法：
```
codeUri: ./
```
现有写法增加以下模式：
1: 指定bucket+key：
```
codeUri: 
    bucket：abc
    key: cde
```
2: 指定bucket+本地路径
```
codeUri: 
    bucket：abc
    path: cde
```

* 新增Tags配置，并删除默认Tags：
```
tags:
      abc: test
      cde: test
```

* 新增生命周期功能
默认增加一个默认存储桶的生命周期，10天后会删除缓存的代码。生命周期规则名：deleteObject， 不会被覆盖。

