### PR TITLE
update web example demo

### DIFF
--- a/example/web/serverless.yml
+++ b/example/web/serverless.yml
@@ -10,7 +10,7 @@ inputs:
   type: web
   name: web-function
   region: ap-chengdu
-  handler: scf_bootstrap
+  handler: index.js # 如果需要自定义启动文件,修改为scf_bootstrap. 详情查看:https://cloud.tencent.com/document/product/583/56126#.E5.B8.B8.E8.A7.81-web-server-.E5.90.AF.E5.8A.A8.E5.91.BD.E4.BB.A4.E6.A8.A1.E7.89.88
   runtime: Nodejs12.16
   events:
     - apigw:


### PR DESCRIPTION
Update the example of a serverless config file for 

* keep it simple for most of bootstrap use cases `/var/lang/${specific_lang}${version}/bin/${specific_lang} {enter_file}`
* keep the availablily for users who need to fully customize the complex bootstrap file. 

according to the changes above:
* if got 405 error, ask users to check Tencent SCF doc and add the customization bootstrap file. 
* after deploy and bootstrap success,  send error message if the port 9000 is not in use.

Things prefer to have.
* Provide complex bootstrap file demo in the help doc with explanation in comments. 
