### PR TITLE
fix: 更新deploy逻辑

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -225,6 +225,8 @@ inputs:
 | image             | 否   | [Image](#Image)                   |                      | 镜像配置                                                                                                                              |
 | protocolType      | 否   | string                            |                      | HTTP 函数支持的访问协议。当前支持 WebSockets 协议，值为 WS,只有 type:web 时此配置生效                                                 |
 | protocolParams    | 否   | [ProtocolParams](#ProtocolParams) |                      | HTTP 函数配置 ProtocolType 访问协议，当前协议可配置的参数，主要是配置空闲超时时间                                                     |
+| provisionedNum    | 否   | number                            |                      | 预置并发数量，注：所有版本的预置并发数总和存在上限限制，当前的上限是：函数最大并发配额 - 100                                          |
+| qualifier         | 否   | number                            |                      | 函数的版本号，注：\$LATEST 版本不支持预置并发                                                                                         |
 
 **重要字段说明**
 

--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,5 +1,5 @@
 name: scf
-version: 0.9.1
+version: 0.9.3
 author: Tencent Cloud, Inc.
 org: Tencent Cloud, Inc.
 description: 单函数组件，允许用户开发部署单个腾讯 SCF 函数实例。适合进行单一函数开发的场景。如：定时触发任务。

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "adm-zip": "^0.5.5",
     "download": "^8.0.0",
-    "tencent-component-toolkit": "^2.22.2",
+    "tencent-component-toolkit": "^2.23.1",
     "type": "^2.0.0"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,7 +275,7 @@ const formatInputs = async (instance, credentials, appId, inputs) => {
           getDefaultServiceName(instance)
 
         let { serviceId } = currentEvent.parameters
-        // currentEvent.parameters.isInputServiceId = !!serviceId
+        currentEvent.parameters.isInputServiceId = !!serviceId
         // currentEvent.parameters.serviceName = serviceName
         currentEvent.parameters.description =
           currentEvent.parameters.description || getDefaultServiceDescription(instance)


### PR DESCRIPTION
修复netTypes，protocol，用户计划更新失败问题，
解开注释：// currentEvent.parameters.isInputServiceId = !!serviceId，使用老的部署逻辑